### PR TITLE
ARM: dts: 15055:  Fix overexposure when capturing photos with flash

### DIFF
--- a/arch/arm/boot/dts/project/15055_HW_11/msm8974-leds.dtsi
+++ b/arch/arm/boot/dts/project/15055_HW_11/msm8974-leds.dtsi
@@ -158,7 +158,7 @@
 			label = "flash";
 			qcom,id = <2>;
 			linux,name = "led:flash_torch";
-			qcom,current = <127>;
+			qcom,current = <190>;
 			qcom,torch-enable;
 		};
 	};

--- a/arch/arm/boot/dts/project/15055_HW_12/msm8974-leds.dtsi
+++ b/arch/arm/boot/dts/project/15055_HW_12/msm8974-leds.dtsi
@@ -158,7 +158,7 @@
 			label = "flash";
 			qcom,id = <2>;
 			linux,name = "led:flash_torch";
-			qcom,current = <127>;
+			qcom,current = <190>;
 			qcom,torch-enable;
 		};
 	};

--- a/arch/arm/boot/dts/project/15055_HW_13/msm8974-leds.dtsi
+++ b/arch/arm/boot/dts/project/15055_HW_13/msm8974-leds.dtsi
@@ -158,7 +158,7 @@
 			label = "flash";
 			qcom,id = <2>;
 			linux,name = "led:flash_torch";
-			qcom,current = <127>;
+			qcom,current = <190>;
 			qcom,torch-enable;
 		};
 	};

--- a/arch/arm/boot/dts/project/15055_HW_14/msm8974-leds.dtsi
+++ b/arch/arm/boot/dts/project/15055_HW_14/msm8974-leds.dtsi
@@ -158,7 +158,7 @@
 			label = "flash";
 			qcom,id = <2>;
 			linux,name = "led:flash_torch";
-			qcom,current = <127>;
+			qcom,current = <190>;
 			qcom,torch-enable;
 		};
 	};

--- a/arch/arm/boot/dts/project/15055_HW_15/msm8974-leds.dtsi
+++ b/arch/arm/boot/dts/project/15055_HW_15/msm8974-leds.dtsi
@@ -158,7 +158,7 @@
 			label = "flash";
 			qcom,id = <2>;
 			linux,name = "led:flash_torch";
-			qcom,current = <127>;
+			qcom,current = <190>;
 			qcom,torch-enable;
 		};
 	};


### PR DESCRIPTION
So, I flashed OOS and noticed that the torch was not nearly as bright as it had been on my kernel, and that exposure with the camera HAL took a hit, so to mitigate that I aligned the voltage for the flash to match what Sultan has been using as it's never failed me with the stock HAL. More info is in the commit message. He can explain things much better than I can.