### PR TITLE
Fix simple ondemand, and synaptics

### DIFF
--- a/drivers/devfreq/devfreq.c
+++ b/drivers/devfreq/devfreq.c
@@ -744,6 +744,26 @@ err_out:
 }
 EXPORT_SYMBOL(devfreq_remove_governor);
 
+int devfreq_policy_add_files(struct devfreq *devfreq,
+			     struct attribute_group attr_group)
+{
+	int ret;
+
+	ret = sysfs_create_group(&devfreq->dev.kobj, &attr_group);
+	if (ret)
+		kobject_put(&devfreq->dev.kobj);
+
+	return ret;
+}
+EXPORT_SYMBOL(devfreq_policy_add_files);
+
+void devfreq_policy_remove_files(struct devfreq *devfreq,
+				 struct attribute_group attr_group)
+{
+	sysfs_remove_group(&devfreq->dev.kobj, &attr_group);
+}
+EXPORT_SYMBOL(devfreq_policy_remove_files);
+
 static ssize_t show_governor(struct device *dev,
 			     struct device_attribute *attr, char *buf)
 {

--- a/drivers/devfreq/governor.h
+++ b/drivers/devfreq/governor.h
@@ -39,4 +39,8 @@ extern int devfreq_add_governor(struct devfreq_governor *governor);
 extern int devfreq_remove_governor(struct devfreq_governor *governor);
 
 extern int devfreq_get_freq_level(struct devfreq *devfreq, unsigned long freq);
+extern int devfreq_policy_add_files(struct devfreq *devfreq,
+				    struct attribute_group attr_group);
+extern void devfreq_policy_remove_files(struct devfreq *devfreq,
+					struct attribute_group attr_group);
 #endif /* _GOVERNOR_H */

--- a/drivers/devfreq/governor_simpleondemand.c
+++ b/drivers/devfreq/governor_simpleondemand.c
@@ -18,6 +18,7 @@
 #define DEVFREQ_SIMPLE_ONDEMAND	"simple_ondemand"
 #define DFSO_UPTHRESHOLD	(80)
 #define DFSO_DOWNDIFFERENTIAL	(20)
+#define FLOOR			(7500)
 
 unsigned int dfso_upthreshold;
 unsigned int dfso_downdifferential;
@@ -44,6 +45,13 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 		stat.busy_time >>= 7;
 		stat.total_time >>= 7;
 	}
+
+	/*
+	 * If the GPU has been active for less than 7.5ms or
+	 * it wasn't busy at all, return early
+	 */
+	if (stat.total_time < FLOOR || !stat.busy_time)
+		return 0;
 
 	if (dfso_simple_scaling) {
 		if (stat.busy_time * 100 >

--- a/drivers/devfreq/governor_simpleondemand.c
+++ b/drivers/devfreq/governor_simpleondemand.c
@@ -16,6 +16,12 @@
 #include "governor.h"
 
 #define DEVFREQ_SIMPLE_ONDEMAND	"simple_ondemand"
+#define DFSO_UPTHRESHOLD	(80)
+#define DFSO_DOWNDIFFERENTIAL	(20)
+
+unsigned int dfso_upthreshold;
+unsigned int dfso_downdifferential;
+unsigned int dfso_simple_scaling;
 
 static int devfreq_simple_ondemand_func(struct devfreq *df,
 					unsigned long *freq,
@@ -24,12 +30,8 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 	struct devfreq_dev_status stat;
 	int err;
 	unsigned long long a, b;
-	struct devfreq_simple_ondemand_data *data = df->data;
 	unsigned long max = (df->max_freq) ? df->max_freq : UINT_MAX;
 	unsigned long min = (df->min_freq) ? df->min_freq : 0;
-
-	if (!data)
-		return -EINVAL;
 
 	stat.private_data = NULL;
 
@@ -43,12 +45,12 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 		stat.total_time >>= 7;
 	}
 
-	if (data && data->simple_scaling) {
+	if (dfso_simple_scaling) {
 		if (stat.busy_time * 100 >
-		    stat.total_time * data->upthreshold)
+		    stat.total_time * dfso_upthreshold)
 			*freq = max;
 		else if (stat.busy_time * 100 <
-		    stat.total_time * data->downdifferential)
+		    stat.total_time * dfso_downdifferential)
 			*freq = min;
 		else
 			*freq = df->previous_freq;
@@ -63,7 +65,7 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 
 	/* Set MAX if it's busy enough */
 	if (stat.busy_time * 100 >
-	    stat.total_time * data->upthreshold) {
+	    stat.total_time * dfso_upthreshold) {
 		*freq = max;
 		return 0;
 	}
@@ -76,7 +78,7 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 
 	/* Keep the current frequency */
 	if (stat.busy_time * 100 >
-	    stat.total_time * (data->upthreshold - data->downdifferential)) {
+	    stat.total_time * (dfso_upthreshold - dfso_downdifferential)) {
 		*freq = stat.current_frequency;
 		return 0;
 	}
@@ -86,7 +88,7 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 	a *= stat.current_frequency;
 	b = div_u64(a, stat.total_time);
 	b *= 100;
-	b = div_u64(b, (data->upthreshold - data->downdifferential / 2));
+	b = div_u64(b, (dfso_upthreshold - dfso_downdifferential / 2));
 	*freq = (unsigned long) b;
 
 	if (df->min_freq && *freq < df->min_freq)
@@ -100,10 +102,7 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 static ssize_t upthreshold_show(struct device *dev,
 				struct device_attribute *attr, char *buf)
 {
-	struct devfreq *devfreq = to_devfreq(dev);
-	struct devfreq_simple_ondemand_data *data = devfreq->data;
-
-	return sprintf(buf, "%d\n", data->upthreshold);
+	return sprintf(buf, "%d\n", dfso_upthreshold);
 }
 
 static ssize_t upthreshold_store(struct device *dev,
@@ -111,14 +110,12 @@ static ssize_t upthreshold_store(struct device *dev,
 				 size_t count)
 {
 	unsigned int val;
-	struct devfreq *devfreq = to_devfreq(dev);
-	struct devfreq_simple_ondemand_data *data = devfreq->data;
 
 	sscanf(buf, "%d", &val);
-	if (val > 100 || val < data->downdifferential)
+	if (val > 100 || val < dfso_downdifferential)
 		return -EINVAL;
 
-	data->upthreshold = val;
+	dfso_upthreshold = val;
 
 	return count;
 }
@@ -126,10 +123,7 @@ static ssize_t upthreshold_store(struct device *dev,
 static ssize_t downdifferential_show(struct device *dev,
 				     struct device_attribute *attr, char *buf)
 {
-	struct devfreq *devfreq = to_devfreq(dev);
-	struct devfreq_simple_ondemand_data *data = devfreq->data;
-
-	return sprintf(buf, "%d\n", data->downdifferential);
+	return sprintf(buf, "%d\n", dfso_downdifferential);
 }
 
 static ssize_t downdifferential_store(struct device *dev,
@@ -137,14 +131,33 @@ static ssize_t downdifferential_store(struct device *dev,
 				      const char *buf, size_t count)
 {
 	unsigned int val;
-	struct devfreq *devfreq = to_devfreq(dev);
-	struct devfreq_simple_ondemand_data *data = devfreq->data;
 
 	sscanf(buf, "%d", &val);
-	if (val > data->upthreshold)
+	if (val > dfso_upthreshold)
 		return -EINVAL;
 
-	data->downdifferential = val;
+	dfso_downdifferential = val;
+
+	return count;
+}
+
+static ssize_t simple_scaling_show(struct device *dev,
+				     struct device_attribute *attr, char *buf)
+{
+	return sprintf(buf, "%d\n", dfso_simple_scaling);
+}
+
+static ssize_t simple_scaling_store(struct device *dev,
+				      struct device_attribute *attr,
+				      const char *buf, size_t count)
+{
+	unsigned int val;
+
+	sscanf(buf, "%d", &val);
+	if (val < 0 || val > 1)
+		return -EINVAL;
+
+	dfso_simple_scaling = val;
 
 	return count;
 }
@@ -152,10 +165,13 @@ static ssize_t downdifferential_store(struct device *dev,
 static DEVICE_ATTR(upthreshold, 0644, upthreshold_show, upthreshold_store);
 static DEVICE_ATTR(downdifferential, 0644, downdifferential_show,
 		   downdifferential_store);
+static DEVICE_ATTR(simple_scaling, 0644, simple_scaling_show,
+		   simple_scaling_store);
 
 static struct attribute *attrs[] = {
 	&dev_attr_upthreshold.attr,
 	&dev_attr_downdifferential.attr,
+	&dev_attr_simple_scaling.attr,
 	NULL,
 };
 
@@ -164,6 +180,23 @@ static struct attribute_group attr_group = {
 	.name = DEVFREQ_SIMPLE_ONDEMAND,
 };
 
+static int devfreq_simple_ondemand_start(struct devfreq *devfreq)
+{
+	dfso_upthreshold = DFSO_UPTHRESHOLD;
+	dfso_downdifferential = DFSO_DOWNDIFFERENTIAL;
+	devfreq_monitor_start(devfreq);
+
+	return devfreq_policy_add_files(devfreq, attr_group);
+}
+
+static int devfreq_simple_ondemand_stop(struct devfreq *devfreq)
+{
+	devfreq_policy_remove_files(devfreq, attr_group);
+	devfreq_monitor_stop(devfreq);
+
+	return 0;
+}
+
 static int devfreq_simple_ondemand_handler(struct devfreq *devfreq,
 				unsigned int event, void *data)
 {
@@ -171,13 +204,11 @@ static int devfreq_simple_ondemand_handler(struct devfreq *devfreq,
 
 	switch (event) {
 	case DEVFREQ_GOV_START:
-		devfreq_monitor_start(devfreq);
-		ret = devfreq_policy_add_files(devfreq, attr_group);
+		ret = devfreq_simple_ondemand_start(devfreq);
 		break;
 
 	case DEVFREQ_GOV_STOP:
-		devfreq_policy_remove_files(devfreq, attr_group);
-		devfreq_monitor_stop(devfreq);
+		devfreq_simple_ondemand_stop(devfreq);
 		break;
 
 	case DEVFREQ_GOV_INTERVAL:

--- a/drivers/devfreq/governor_simpleondemand.c
+++ b/drivers/devfreq/governor_simpleondemand.c
@@ -23,7 +23,7 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 					u32 *flag)
 {
 	struct devfreq_dev_status stat;
-	int err = df->profile->get_dev_status(df->dev.parent, &stat);
+	int err;
 	unsigned long long a, b;
 	unsigned int dfso_upthreshold = DFSO_UPTHRESHOLD;
 	unsigned int dfso_downdifferential = DFSO_DOWNDIFFERENCTIAL;
@@ -31,6 +31,9 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 	unsigned long max = (df->max_freq) ? df->max_freq : UINT_MAX;
 	unsigned long min = (df->min_freq) ? df->min_freq : 0;
 
+	stat.private_data = NULL;
+
+	err = df->profile->get_dev_status(df->dev.parent, &stat);
 	if (err)
 		return err;
 

--- a/drivers/devfreq/governor_simpleondemand.c
+++ b/drivers/devfreq/governor_simpleondemand.c
@@ -50,7 +50,8 @@ static int devfreq_simple_ondemand_func(struct devfreq *df,
 		    stat.total_time * dfso_upthreshold)
 			*freq = max;
 		else if (stat.busy_time * 100 <
-		    stat.total_time * dfso_downdifferential)
+			 stat.total_time *
+			 (dfso_upthreshold - dfso_downdifferential))
 			*freq = min;
 		else
 			*freq = df->previous_freq;

--- a/drivers/input/touchscreen/synaptics_driver_s3508.c
+++ b/drivers/input/touchscreen/synaptics_driver_s3508.c
@@ -4686,12 +4686,12 @@ static int synaptics_ts_probe(
 	/***power_init*****/
 
 	mutex_init(&ts->mutex);
-	synaptics_wq = create_singlethread_workqueue("synaptics_wq");
+	synaptics_wq = alloc_ordered_workqueue("synaptics_wq", WQ_HIGHPRI);
     if( !synaptics_wq ){
         ret = -ENOMEM;
 		goto err_alloc_data_failed;
     }
-	speedup_resume_wq = create_singlethread_workqueue("speedup_resume_wq");
+	speedup_resume_wq = alloc_ordered_workqueue("speedup_resume_wq", WQ_HIGHPRI);
 	if( !speedup_resume_wq ){
          ret = -ENOMEM;
 		goto err_alloc_data_failed;

--- a/drivers/input/touchscreen/synaptics_driver_s3508.c
+++ b/drivers/input/touchscreen/synaptics_driver_s3508.c
@@ -4035,7 +4035,7 @@ static const struct file_operations sleep_mode_enable_proc_fops = {
 
 static const struct file_operations tp_reset_proc_fops = {
 	.write = tp_write_func,
-	//.read =  tp_sleep_read_func,
+	.read =  tp_sleep_read_func,
 	.open = simple_open,
 	.owner = THIS_MODULE,
 };

--- a/drivers/input/touchscreen/synaptics_dsx_i2c.c
+++ b/drivers/input/touchscreen/synaptics_dsx_i2c.c
@@ -4831,11 +4831,10 @@ static int __devinit synaptics_rmi4_probe(struct i2c_client *client,
 		exp_data.initialized = true;
 	}
 
-
 	if(!(get_boot_mode() == MSM_BOOT_MODE__FACTORY ||
 				get_boot_mode() == MSM_BOOT_MODE__RF ||
 				get_boot_mode() == MSM_BOOT_MODE__WLAN) ) {
-		exp_data.workqueue = create_singlethread_workqueue("dsx_exp_workqueue");
+		exp_data.workqueue = alloc_ordered_workqueue("dsx_exp_workqueue", WQ_HIGHPRI);
 		INIT_DELAYED_WORK(&exp_data.work, synaptics_rmi4_exp_fn_work);
 		exp_data.rmi4_data = rmi4_data;
 		exp_data.queue_work = true;

--- a/drivers/input/touchscreen/synaptics_rmi_dev.c
+++ b/drivers/input/touchscreen/synaptics_rmi_dev.c
@@ -291,7 +291,7 @@ static ssize_t rmidev_read(struct file *filp, char __user *buf,
 		size_t count, loff_t *f_pos)
 {
 	ssize_t retval;
-	unsigned char tmpbuf[count + 1];
+	unsigned char *tmpbuf;
 	struct rmidev_data *dev_data = filp->private_data;
 
 	if (IS_ERR(dev_data)) {
@@ -304,6 +304,10 @@ static ssize_t rmidev_read(struct file *filp, char __user *buf,
 
 	if (count > (REG_ADDR_LIMIT - *f_pos))
 		count = REG_ADDR_LIMIT - *f_pos;
+
+	tmpbuf = kzalloc(count + 1, GFP_KERNEL);
+	if (!tmpbuf)
+		return -ENOMEM;
 
 	mutex_lock(&(dev_data->file_mutex));
 
@@ -322,6 +326,7 @@ static ssize_t rmidev_read(struct file *filp, char __user *buf,
 clean_up:
 	mutex_unlock(&(dev_data->file_mutex));
 
+	kfree(tmpbuf);
 	return retval;
 }
 
@@ -337,7 +342,7 @@ static ssize_t rmidev_write(struct file *filp, const char __user *buf,
 		size_t count, loff_t *f_pos)
 {
 	ssize_t retval;
-	unsigned char tmpbuf[count + 1];
+	unsigned char *tmpbuf;
 	struct rmidev_data *dev_data = filp->private_data;
 
 	if (IS_ERR(dev_data)) {
@@ -351,8 +356,14 @@ static ssize_t rmidev_write(struct file *filp, const char __user *buf,
 	if (count > (REG_ADDR_LIMIT - *f_pos))
 		count = REG_ADDR_LIMIT - *f_pos;
 
-	if (copy_from_user(tmpbuf, buf, count))
+	tmpbuf = kzalloc(count + 1, GFP_KERNEL);
+	if (!tmpbuf)
+		return -ENOMEM;
+
+	if (copy_from_user(tmpbuf, buf, count)) {
+		kfree(tmpbuf);
 		return -EFAULT;
+	}
 
 	mutex_lock(&(dev_data->file_mutex));
 
@@ -364,7 +375,7 @@ static ssize_t rmidev_write(struct file *filp, const char __user *buf,
 		*f_pos += retval;
 
 	mutex_unlock(&(dev_data->file_mutex));
-
+	kfree(tmpbuf);
 	return retval;
 }
 


### PR DESCRIPTION
Without read during suspend enabled in our TP driver, then it is impossible for virtual keys to awake from suspend. This in turn causes a kernel panic as the display driver relies on virtual keys for functionality as a backend. I also noticed that by using high priority workqueues, latency is vastly decreased.

This also fixes simple ondemand crashing on user selection, and makes it practical for use amongst end users